### PR TITLE
add logLik-generic

### DIFF
--- a/R/generics.R
+++ b/R/generics.R
@@ -1,3 +1,34 @@
+#' @method logLik felm
+#' @export
+logLik.felm <- function(object, ...) {
+  res <- object$residuals
+  p <- object$rank
+  w <- object$weights
+
+  N <- length(res)
+
+  if (is.null(w)) {
+    w <- rep.int(1, N)
+  } else {
+    excl <- w == 0
+    if (any(excl)) {
+      res <- res[!excl]
+      N <- length(res)
+      w <- w[!excl]
+    }
+  }
+  N0 <- N
+
+  val <- 0.5 * (sum(log(w)) - N * (log(2 * pi) + 1 - log(N) + log(sum(w * res^2))))
+
+  attr(val, "nall") <- N0
+  attr(val, "nobs") <- N
+  attr(val, "df") <- p + 1
+  class(val) <- "logLik"
+
+  val
+}
+
 #' @method print felm
 #' @export
 print.felm <- function(x,digits=max(3,getOption('digits')-3),...) {


### PR DESCRIPTION
Would be nice to have a `logLik()` for *felm*-objects, so `AIC()` also works on *felm*-objects. Is the log-Likelihood similar straightforward to compute as for linear models? If so, this PR should implement `logLik()` for * felm*.