### PR TITLE
new confint.felm to solve issue #16

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 S3method(bread,felm)
 S3method(coef,felm)
+S3method(confint,felm)
 S3method(estfun,felm)
 S3method(model.frame,felm)
 S3method(model.matrix,felm)

--- a/R/generics.R
+++ b/R/generics.R
@@ -74,9 +74,9 @@ residuals.felm <- function(object, ..., lhs=NULL) {
 }
 #' @method vcov felm
 #' @export
-vcov.felm <- function(object,...,type, lhs=NULL) {
+vcov.felm <- function(object,..., type=NULL, lhs=NULL) {
 #  if(is.na(match(type[1], c('iid', 'robust', 'cluster'))))
-  if(missing(type)) type <- if(is.null(object$clustervar)) {
+  if(is.null(type)) type <- if(is.null(object$clustervar)) {
                               if(getOption('lfe.robust')) 'robust' else 'iid'
                             } else 'cluster'
   if(!(type[1] %in% c('iid', 'robust', 'cluster')))
@@ -99,6 +99,50 @@ vcov.felm <- function(object,...,type, lhs=NULL) {
   if(type[1] == 'iid') return(object$STATS[[lhs]]$vcv)
   if(type[1] == 'robust') return(object$STATS[[lhs]]$robustvcv)
   if(type[1] == 'cluster') return(object$STATS[[lhs]]$clustervcv)
+}
+
+
+#' @method confint felm
+#' @export
+confint.felm <- function (object, parm=NULL, level = 0.95, lhs=NULL, type=NULL, ...) {
+  is_multi <- length(object$lhs)>1
+  
+  if(is_multi & is.null(lhs)) {
+    lhs <- object$lhs
+    res_list <- lapply(object$lhs, function(x) confint_one(object, lhs=x, parm=parm, level = level, type = type, ...))
+    res <- do.call("rbind", res_list)
+    rownames(res) <-  paste(rep(lhs, each = object$Pp), rownames(res), sep=":")
+  } else {
+    res <- confint_one(object, parm=parm, level = level, lhs=lhs, type = type, ...)
+  }
+  res
+}
+
+## usecopy/paste stats:::format.perc as would be forbidden to import unexported one
+stats_format_perc <- function (probs, digits) paste(format(100 * probs, trim = TRUE, scientific = FALSE, digits = digits), "%")
+
+# low level function for confint, working for only one lhs
+confint_one <- function (object, parm=NULL, level = 0.95, lhs=NULL, type=NULL, ...) 
+{
+  
+  cf <- coef(object, lhs = lhs)
+  if(is.matrix(cf)) {
+    cf <- drop(cf)
+  }
+  pnames <- names(cf)
+  if (is.null(parm)) 
+    parm <- pnames
+  else if (is.numeric(parm)) 
+    parm <- pnames[parm]
+  a <- (1 - level)/2
+  a <- c(a, 1 - a)
+  pct <- stats_format_perc(a, 3)
+  fac <- qt(a, object$df.residual)
+  ci <- array(NA, dim = c(length(parm), 2L), dimnames = list(parm, 
+                                                             pct))
+  ses <- sqrt(diag(vcov(object, lhs = lhs, type = type)))[parm]
+  ci[] <- cf[parm] + ses %o% fac
+  ci
 }
 
 #' @method update felm

--- a/R/generics.R
+++ b/R/generics.R
@@ -127,7 +127,7 @@ confint_one <- function (object, parm=NULL, level = 0.95, lhs=NULL, type=NULL, .
   
   cf <- coef(object, lhs = lhs)
   if(is.matrix(cf)) {
-    cf <- drop(cf)
+    cf <- setNames(drop(cf), rownames(cf)) ## drop removes name if 1,1 matrix!
   }
   pnames <- names(cf)
   if (is.null(parm)) 

--- a/tests/comparelm.R
+++ b/tests/comparelm.R
@@ -26,8 +26,11 @@ all.equal(coef(smry_est), coef(smry_est_lm)[c("x", "x2"),])
 
 ## vcov, confint
 all.equal(vcov(est), vcov(est_lm)[c("x", "x2"), c("x", "x2")])
+all.equal(confint(est), confint(est_lm, parm = c("x", "x2")))
 all.equal(stats::confint.default(est), stats::confint.default(est_lm, parm = c("x", "x2")))
 
+## should differ:
+isTRUE(all.equal(confint(est, type ="iid"), confint(est, type ="robust")))
 
 ## multi response
 est_felm_multi <- felm(y + y2 ~ x+x2 | id + firm)
@@ -38,3 +41,7 @@ all.equal(coef(summary(est_felm_multi, lhs = "y")),
           coef(summary(est_lm_multi))[[1]][c("x", "x2"),])
 all.equal(coef(summary(est_felm_multi, lhs = "y2")),
           coef(summary(est_lm_multi))[[2]][c("x", "x2"),])
+
+all.equal(confint(est_felm_multi),
+          confint(est_lm_multi)[c("y:x", "y:x2", "y2:x", "y2:x2"),])
+

--- a/tests/comparelm.R
+++ b/tests/comparelm.R
@@ -14,8 +14,27 @@ firm.eff <- rnorm(nlevels(firm))
 
 ## left hand side
 y <- x + 0.25*x2 + id.eff[id] + firm.eff[firm] + rnorm(length(x))
+y2 <- 0.1*x + 0.2*x2 + id.eff[id] + firm.eff[firm] + rnorm(length(x))
 
 ## estimate
-summary(est <- felm(y ~ x+x2 | id + firm))
+smry_est <- summary(est <- felm(y ~ x+x2 | id + firm))
 getfe(est)
-summary(lm(y ~ x + x2 + id + firm))
+smry_est_lm <- summary(est_lm <- lm(y ~ x + x2 + id + firm))
+smry_est_lm
+
+all.equal(coef(smry_est), coef(smry_est_lm)[c("x", "x2"),])
+
+## vcov, confint
+all.equal(vcov(est), vcov(est_lm)[c("x", "x2"), c("x", "x2")])
+all.equal(stats::confint.default(est), stats::confint.default(est_lm, parm = c("x", "x2")))
+
+
+## multi response
+est_felm_multi <- felm(y + y2 ~ x+x2 | id + firm)
+est_lm_multi <- lm(cbind(y, y2) ~ x+x2 + id + firm)
+
+all.equal(coef(est_felm_multi), coef(est_lm_multi)[c("x", "x2"),])
+all.equal(coef(summary(est_felm_multi, lhs = "y")),
+          coef(summary(est_lm_multi))[[1]][c("x", "x2"),])
+all.equal(coef(summary(est_felm_multi, lhs = "y2")),
+          coef(summary(est_lm_multi))[[2]][c("x", "x2"),])

--- a/tests/comparelm.Rout.save
+++ b/tests/comparelm.Rout.save
@@ -99,9 +99,14 @@ F-statistic:  112 on 16 and 483 DF,  p-value: <2e-16
 > ## vcov, confint
 > all.equal(vcov(est), vcov(est_lm)[c("x", "x2"), c("x", "x2")])
 [1] TRUE
+> all.equal(confint(est), confint(est_lm, parm = c("x", "x2")))
+[1] TRUE
 > all.equal(stats::confint.default(est), stats::confint.default(est_lm, parm = c("x", "x2")))
 [1] TRUE
 > 
+> ## should differ:
+> isTRUE(all.equal(confint(est, type ="iid"), confint(est, type ="robust")))
+[1] FALSE
 > 
 > ## multi response
 > est_felm_multi <- felm(y + y2 ~ x+x2 | id + firm)
@@ -116,6 +121,11 @@ F-statistic:  112 on 16 and 483 DF,  p-value: <2e-16
 +           coef(summary(est_lm_multi))[[2]][c("x", "x2"),])
 [1] TRUE
 > 
+> all.equal(confint(est_felm_multi),
++           confint(est_lm_multi)[c("y:x", "y:x2", "y2:x", "y2:x2"),])
+[1] TRUE
+> 
+> 
 > proc.time()
    user  system elapsed 
-  1.363   0.117   1.493 
+  1.424   0.137   1.748 

--- a/tests/comparelm.Rout.save
+++ b/tests/comparelm.Rout.save
@@ -1,11 +1,13 @@
 
-R Under development (unstable) (2019-03-09 r76219) -- "Unsuffered Consequences"
+R version 3.6.0 (2019-04-26) -- "Planting of a Tree"
 Copyright (C) 2019 The R Foundation for Statistical Computing
 Platform: x86_64-pc-linux-gnu (64-bit)
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
 Type 'license()' or 'licence()' for distribution details.
+
+  Natural language support but running in an English locale
 
 R is a collaborative project with many contributors.
 Type 'contributors()' for more information and
@@ -32,31 +34,10 @@ Loading required package: Matrix
 > 
 > ## left hand side
 > y <- x + 0.25*x2 + id.eff[id] + firm.eff[firm] + rnorm(length(x))
+> y2 <- 0.1*x + 0.2*x2 + id.eff[id] + firm.eff[firm] + rnorm(length(x))
 > 
 > ## estimate
-> summary(est <- felm(y ~ x+x2 | id + firm))
-
-Call:
-   felm(formula = y ~ x + x2 | id + firm) 
-
-Residuals:
-   Min     1Q Median     3Q    Max 
--3.360 -0.665 -0.030  0.764  2.618 
-
-Coefficients:
-   Estimate Std. Error t value Pr(>|t|)    
-x    0.9692     0.0488   19.88  < 2e-16 ***
-x2   0.3346     0.0484    6.91  1.6e-11 ***
----
-Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
-
-Residual standard error: 1.03 on 483 degrees of freedom
-Multiple R-squared(full model): 0.787   Adjusted R-squared: 0.78 
-Multiple R-squared(proj model): 0.484   Adjusted R-squared: 0.467 
-F-statistic(full model): 112 on 16 and 483 DF, p-value: <2e-16 
-F-statistic(proj model):  227 on 2 and 483 DF, p-value: <2e-16 
-
-
+> smry_est <- summary(est <- felm(y ~ x+x2 | id + firm))
 > getfe(est)
            effect obs comp   fe idx
 id.1   -1.6363769  43    1   id   1
@@ -75,7 +56,8 @@ firm.3  0.7307192  81    1 firm   3
 firm.4  0.7251559  70    1 firm   4
 firm.5 -1.5010210  61    1 firm   5
 firm.6  2.2462290  77    1 firm   6
-> summary(lm(y ~ x + x2 + id + firm))
+> smry_est_lm <- summary(est_lm <- lm(y ~ x + x2 + id + firm))
+> smry_est_lm
 
 Call:
 lm(formula = y ~ x + x2 + id + firm)
@@ -104,13 +86,36 @@ firm4         0.7252     0.1540    4.71  3.3e-06 ***
 firm5        -1.5010     0.1604   -9.36  < 2e-16 ***
 firm6         2.2462     0.1500   14.97  < 2e-16 ***
 ---
-Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
+Signif. codes:  0 ‘***’ 0.001 ‘**’ 0.01 ‘*’ 0.05 ‘.’ 0.1 ‘ ’ 1
 
 Residual standard error: 1.03 on 483 degrees of freedom
 Multiple R-squared:  0.787,	Adjusted R-squared:  0.78 
 F-statistic:  112 on 16 and 483 DF,  p-value: <2e-16
 
 > 
+> all.equal(coef(smry_est), coef(smry_est_lm)[c("x", "x2"),])
+[1] TRUE
+> 
+> ## vcov, confint
+> all.equal(vcov(est), vcov(est_lm)[c("x", "x2"), c("x", "x2")])
+[1] TRUE
+> all.equal(stats::confint.default(est), stats::confint.default(est_lm, parm = c("x", "x2")))
+[1] TRUE
+> 
+> 
+> ## multi response
+> est_felm_multi <- felm(y + y2 ~ x+x2 | id + firm)
+> est_lm_multi <- lm(cbind(y, y2) ~ x+x2 + id + firm)
+> 
+> all.equal(coef(est_felm_multi), coef(est_lm_multi)[c("x", "x2"),])
+[1] TRUE
+> all.equal(coef(summary(est_felm_multi, lhs = "y")),
++           coef(summary(est_lm_multi))[[1]][c("x", "x2"),])
+[1] TRUE
+> all.equal(coef(summary(est_felm_multi, lhs = "y2")),
++           coef(summary(est_lm_multi))[[2]][c("x", "x2"),])
+[1] TRUE
+> 
 > proc.time()
    user  system elapsed 
-  1.637   0.578   1.516 
+  1.363   0.117   1.493 


### PR DESCRIPTION
Here is my proposed confint.felm. 

Note that:

1. I use object$Pp for number of non-rpojected parameters, is that correct?
2. I had to change `vcov.felm(, type, )` to `vcov.felm(, type=NULL, )`. Reason is calling internally a function with missing argument (i.e. `function(type) vcov(type=type)`) is very tricky. I hope this is fine?
3. Implementation follows closely confint for mlm object, with response and coef names appended in rownames. This is arguably not the best way (broom::tidy with one column for each response and coef is much better) but I followed lm practice. 

New code solves the two issues:

``` r
library(lfe)
#> Loading required package: Matrix
packageVersion("lfe")
#> [1] '2.8.3'

example(felm, echo = FALSE)
y2 <- 0.1*x + 0.5*x2 + id.eff[id] + firm.eff[firm] + u

est_multi <- felm(y+y2 ~ x+x2| id + firm)


## first issue: multi reaponse won't work
confint(est_multi)
#>             2.5 %     97.5 %
#> y:x   -0.62600547 -0.4483667
#> y:x2   0.45474747  0.6332051
#> y2:x   0.05134531  0.1747880
#> y2:x2  0.44281269  0.5668245
confint(est_multi, lhs = "y")
#>         2.5 %     97.5 %
#> x  -0.6260055 -0.4483667
#> x2  0.4547475  0.6332051

## second issue: cannot pass type
all.equal(confint(est, type = "robust"), confint(est, type = "iid"))
#> [1] "Mean relative difference: 0.002653641"
```
