### PR TITLE
Update configure.ac (and configure)

### DIFF
--- a/configure
+++ b/configure
@@ -1897,6 +1897,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
 ac_config_headers="$ac_config_headers src/config.h"
 
 ac_aux_dir=
@@ -2051,6 +2052,7 @@ ac_config_files="$ac_config_files src/Makevars"
 
 
 
+# AC_LANG(C)
 # Check whether --enable-threads was given.
 if test "${enable_threads+set}" = set; then :
   enableval=$enable_threads; do_threads=$enableval
@@ -2067,6 +2069,7 @@ $as_echo "#define HUGE_INT 1" >>confdefs.h
 fi
 
 
+# local debug
 # Check whether --enable-pedantry was given.
 if test "${enable_pedantry+set}" = set; then :
   enableval=$enable_pedantry; DFLAGS='-Wall -Wextra -Wpedantic'
@@ -3957,6 +3960,7 @@ See \`config.log' for more details" "$LINENO" 5; }
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
+
 #include <semaphore.h>
  #include <stdlib.h>
  #include <stdio.h>

--- a/configure.ac
+++ b/configure.ac
@@ -1,13 +1,14 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
-AC_PREREQ([2.67])
-AC_INIT([lfe])
+AC_PREREQ([2.69])
+AC_INIT
+AC_CONFIG_SRCDIR([lfe])
 AC_CONFIG_SRCDIR([src/lfe.c])
 AC_CONFIG_HEADERS([src/config.h])
 AC_CONFIG_AUX_DIR([build/autoconf])
 AC_CONFIG_FILES([src/Makevars])
 m4_include([tools/ax_pthread.m4])
-dnl AC_LANG(C)
+# AC_LANG(C)
 AC_ARG_ENABLE([threads],
         [AS_HELP_STRING([--disable-threads],[do not use threads])],
         [do_threads=$enableval],[do_threads=yes])
@@ -17,7 +18,7 @@ AC_ARG_ENABLE([huge],
 	[AC_DEFINE([HUGE_INT], [1], [64bit])],
 	[])
 
-dnl local debug 
+# local debug
 AC_ARG_ENABLE([pedantry],,
 	[DFLAGS='-Wall -Wextra -Wpedantic'],
 	[])
@@ -55,8 +56,8 @@ AC_MSG_CHECKING(for timed semaphore wait)
 # we may use these when checking for semaphores
 LDFLAGS="$LDFLAGS $PTHREAD_LIBS"
 CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
-AC_TRY_RUN(dnl
-[#include <semaphore.h>
+AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#include <semaphore.h>
  #include <stdlib.h>
  #include <stdio.h>
  #include <errno.h>
@@ -76,11 +77,9 @@ AC_TRY_RUN(dnl
     }
     exit(0);
   }
-],
-AC_MSG_RESULT(yes)
-AC_DEFINE([HAVE_SEM], [1], [timed sem wait]),
-AC_MSG_RESULT(no)
-)
+]])],[AC_MSG_RESULT(yes)
+AC_DEFINE(HAVE_SEM, 1, timed sem wait)],[AC_MSG_RESULT(no)
+],[])
 
 # check for capability of setting thread name
 AC_SEARCH_LIBS([pthread_setname_np], [], AC_DEFINE([HAVE_THREADNAME],1, [chg thread name]), [], [$PTHREAD_CFLAGS])


### PR DESCRIPTION
This was triggered by the _cri de coeur_ in [this tweet](https://twitter.com/TomZylkin/status/1457042749044178953). I got the same note from CRAN and fixed it in half a dozen packages via a simple routine update as suggested.  Here I only did one more editing step of replace the (old) comment sequence `dnl` with the newer (more standard) `#`.  As always, the file to look at is `configure.ac` with `configure` being machine-generated and not meant for human consumption.